### PR TITLE
Renamed vuer-related files to vuer, and removed it from unrelated fil…

### DIFF
--- a/elrik_bringup/README.md
+++ b/elrik_bringup/README.md
@@ -27,7 +27,7 @@ The `launch` folder is divided into two folders, for launch files that should be
    ```
 2. In another terminal, run teleoperation (and IK but no camera) with:
    ```
-   ros2 launch elrik_bringup teleoperation.launch.py camera_enabled:=false rviz:=false
+   ros2 launch elrik_bringup teleoperation_vuer.launch.py camera_enabled:=false rviz:=false
    ```
 3. In the headset's browser, go to the adress: `127.0.0.1:8012`
 

--- a/elrik_bringup/launch/server/teleoperation_vuer.launch.py
+++ b/elrik_bringup/launch/server/teleoperation_vuer.launch.py
@@ -32,9 +32,9 @@ def launch_setup(context, *args, **kwargs):
         launch_arguments={"rviz": rviz}.items(),
     )
 
-    teleoperation_node = Node(
+    teleoperation_vuer_node = Node(
         package="teleoperation",
-        executable="teleoperation_node",
+        executable="teleoperation_vuer_node",
         output="screen",
         remappings=[
             ("/image_left", image_topic_left),
@@ -47,7 +47,7 @@ def launch_setup(context, *args, **kwargs):
 
     return [
         ik_control_launch,
-        teleoperation_node,
+        teleoperation_vuer_node,
     ]
 
 

--- a/pkgs_teleoperation/teleoperation/setup.py
+++ b/pkgs_teleoperation/teleoperation/setup.py
@@ -19,7 +19,7 @@ setup(
     tests_require=["pytest"],
     entry_points={
         "console_scripts": [
-            "teleoperation_node = teleoperation.teleoperation_node:main"
+            "teleoperation_vuer_node = teleoperation.teleoperation_vuer_node:main"
         ],
     },
 )

--- a/pkgs_teleoperation/teleoperation/teleoperation/src/tracking_collision_avoidance.py
+++ b/pkgs_teleoperation/teleoperation/teleoperation/src/tracking_collision_avoidance.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-class VuerCollisionAvoidance:
+class TrackingCollisionAvoidance:
     def __init__(self, safety_threshold=0.3):
 
         self.safety_threshold = safety_threshold
@@ -20,11 +20,11 @@ class VuerCollisionAvoidance:
         else:
             return mat
 
-    def process(self, vuer_left_mat, vuer_right_mat):
+    def process(self, tracked_left_mat, tracked_right_mat):
 
         # Check valid matrix
-        left_mat = self.mat_update(self.left_mat_prev, vuer_left_mat.copy())
-        right_mat = self.mat_update(self.right_mat_prev, vuer_right_mat.copy())
+        left_mat = self.mat_update(self.left_mat_prev, tracked_left_mat.copy())
+        right_mat = self.mat_update(self.right_mat_prev, tracked_right_mat.copy())
 
         left_pos = left_mat[0:3, 3]
         right_pos = right_mat[0:3, 3]

--- a/pkgs_teleoperation/teleoperation/teleoperation/teleoperation_vuer_node.py
+++ b/pkgs_teleoperation/teleoperation/teleoperation/teleoperation_vuer_node.py
@@ -1,0 +1,143 @@
+from scipy.spatial.transform import Rotation
+
+from cv_bridge import CvBridge
+import rclpy
+from rclpy.node import Node
+from geometry_msgs.msg import PoseStamped, Pose, Point, Quaternion
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import Header
+from sensor_msgs.msg import JointState
+
+from teleoperation.src.vuer_app import VuerApp
+from teleoperation.src.tracking_transformer import TrackingTransformer
+from teleoperation.src.tracking_collision_avoidance import TrackingCollisionAvoidance
+
+
+class TeleoperationVuerNode(Node):
+
+    def __init__(self):
+        super().__init__("teleoperation_vuer_node")
+
+        # Parameters
+        self.declare_parameter("fps", 30)
+        self.fps = self.get_parameter("fps").get_parameter_value().integer_value
+
+        self.declare_parameter("camera_enabled", True)
+        self.camera_enabled = (
+            self.get_parameter("camera_enabled").get_parameter_value().bool_value
+        )
+
+        # Subscribers
+        self.subscription_image_left = self.create_subscription(
+            CompressedImage, "/image_left", self.callback_image_left, 1
+        )
+
+        self.subscription_image_right = self.create_subscription(
+            CompressedImage, "/image_right", self.callback_image_right, 1
+        )
+
+        # Publishers
+        self.pose_left_pub = self.create_publisher(
+            PoseStamped, "/link_left_hand/target_pose", 1
+        )
+
+        self.pose_right_pub = self.create_publisher(
+            PoseStamped, "/link_right_hand/target_pose", 1
+        )
+
+        self.joint_state_hands_pub = self.create_publisher(
+            JointState, "/joint_states_hands", 1
+        )
+
+        # Timers
+        self.timer = self.create_timer(1.0 / self.fps, self.callback_timer)
+
+        # Variables
+        self.image_left = None
+        self.image_right = None
+
+        self.cv_bridge = CvBridge()
+
+        self.vuer_app = VuerApp(self.camera_enabled)
+        self.tracking_transformer = TrackingTransformer()
+        self.tracking_collision_avoidance = TrackingCollisionAvoidance()
+
+    def callback_image_left(self, msg):
+        self.image_left = self.cv_bridge.compressed_imgmsg_to_cv2(
+            msg, desired_encoding="rgb8"
+        )
+
+    def callback_image_right(self, msg):
+        self.image_right = self.cv_bridge.compressed_imgmsg_to_cv2(
+            msg, desired_encoding="rgb8"
+        )
+
+    def tf_matrix_to_msg(self, tf_matrix):
+        position = tf_matrix[0:3, 3]
+
+        rotation_matrix = tf_matrix[0:3, 0:3]
+        rotation = Rotation.from_matrix(rotation_matrix)
+        quaternion = rotation.as_quat()
+
+        msg = PoseStamped(
+            header=Header(frame_id="link_torso", stamp=self.get_clock().now().to_msg()),
+            pose=Pose(
+                position=Point(x=position[0], y=position[1], z=position[2]),
+                orientation=Quaternion(
+                    x=quaternion[0], y=quaternion[1], z=quaternion[2], w=quaternion[3]
+                ),
+            ),
+        )
+
+        return msg
+
+    def dict_to_joint_state_msg(self, dict):
+        names = list(dict.keys())
+        positions = list(dict.values())
+
+        joint_state_msg = JointState()
+        joint_state_msg.header.stamp = self.get_clock().now().to_msg()
+        joint_state_msg.name = names
+        joint_state_msg.position = positions
+
+        return joint_state_msg
+
+    def callback_timer(self):
+        self.vuer_app.update_frames(self.image_left, self.image_right)
+
+        # Transform tracking to robot frame
+        _, left_wrist_mat, right_wrist_mat, hand_angles = (
+            self.tracking_transformer.process(
+                self.vuer_app.head_matrix,
+                self.vuer_app.hand_left,
+                self.vuer_app.hand_right,
+            )
+        )
+
+        # Avoid hand collision
+        left_wrist_mat, right_wrist_mat = self.tracking_collision_avoidance.process(
+            left_wrist_mat, right_wrist_mat
+        )
+
+        msg_pose_left = self.tf_matrix_to_msg(left_wrist_mat)
+        self.pose_left_pub.publish(msg_pose_left)
+
+        msg_pose_right = self.tf_matrix_to_msg(right_wrist_mat)
+        self.pose_right_pub.publish(msg_pose_right)
+
+        msg_angles_hands = self.dict_to_joint_state_msg(hand_angles)
+        self.joint_state_hands_pub.publish(msg_angles_hands)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    teleoperation_vuer_node = TeleoperationVuerNode()
+
+    rclpy.spin(teleoperation_vuer_node)
+    teleoperation_vuer_node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# WHY
To be able to more easily change teleoperation methods, the current classes should be Vuer-independent where possible.

# WHAT
Renamed vuer-related files to prepend vuer, and removed it from unrelated functions.