### PR TITLE
Increase servo write speed

### DIFF
--- a/elrik_bringup/README.md
+++ b/elrik_bringup/README.md
@@ -5,6 +5,12 @@ Bringup package for Elrik, with different launch scripts for each mode/feature.
 This package contains lots of launch files that implements different behaviours/modes, like face following or teleoperation.
 The `launch` folder is divided into two folders, for launch files that should be run directly on the robot micorcomputer, and those to be run on a "server", aka. a development computer connected to the same subnet. 
 
+Install dependencies with:
+
+```
+rosdep install --from-paths src -y --ignore-src
+```
+
 ## Teleoperation
 
 ### Setup VR Headset

--- a/elrik_bringup/launch/server/slider_control.launch.py
+++ b/elrik_bringup/launch/server/slider_control.launch.py
@@ -1,0 +1,59 @@
+from launch import LaunchDescription
+from launch.actions import (
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
+from launch.substitutions import PathJoinSubstitution
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.substitutions import FindPackageShare
+
+
+package_name = "elrik_bringup"
+
+
+def launch_setup(context, *args, **kwargs):
+
+    urdf_file = PathJoinSubstitution(
+        [
+            FindPackageShare("elrik_description"),
+            "urdf",
+            "phobos_generated.urdf",
+        ]
+    )
+
+    rviz_config_file = PathJoinSubstitution(
+        [
+            FindPackageShare(package_name),
+            "config",
+            "rviz",
+            "teleoperation.rviz",
+        ]
+    )
+
+    urdf_display_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                FindPackageShare("urdf_launch"),
+                "/launch",
+                "/display.launch.py",
+            ]
+        ),
+        launch_arguments={
+            "urdf_package": "elrik_description",
+            "urdf_package_path": urdf_file,
+            "rviz_config": rviz_config_file,
+        }.items(),
+    )
+
+    return [
+        urdf_display_launch,
+    ]
+
+
+def generate_launch_description():
+
+    return LaunchDescription(
+        [
+            OpaqueFunction(function=launch_setup),
+        ]
+    )

--- a/elrik_bringup/package.xml
+++ b/elrik_bringup/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>urdf_launch</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/pkgs_control/servo_control/servo_control/servo_manager_node.py
+++ b/pkgs_control/servo_control/servo_control/servo_manager_node.py
@@ -19,14 +19,14 @@ class ServoManagerNode(Node):
         super().__init__("servo_manager_node")
 
         # Parameters
-        self.declare_parameter("control_frequency_arms", 0.1)
+        self.declare_parameter("control_frequency_arms", 10.0)
         self.control_frequency_arms = (
             self.get_parameter("control_frequency_arms")
             .get_parameter_value()
             .double_value
         )
 
-        self.declare_parameter("control_frequency_hands", 1.0 / 30.0)
+        self.declare_parameter("control_frequency_hands", 30.0)
         self.control_frequency_hands = (
             self.get_parameter("control_frequency_hands")
             .get_parameter_value()
@@ -49,11 +49,11 @@ class ServoManagerNode(Node):
 
         # Timers
         self.timer_arms = self.create_timer(
-            self.control_frequency_arms, self.callback_timer_arms
+            1.0 / self.control_frequency_arms, self.callback_timer_arms
         )
 
         self.timer_hands = self.create_timer(
-            self.control_frequency_hands, self.callback_timer_hands
+            1.0 / self.control_frequency_hands, self.callback_timer_hands
         )
 
         # Node variables
@@ -74,7 +74,9 @@ class ServoManagerNode(Node):
             f"{config_folder_path}/servo_hand_left_params.json",
         ]
         self.driver_hand_left = ElrikDriverHandLeft(
-            json_files_hand_left, self.control_frequency_hands, synchronise_speed=False
+            json_files_hand_left,
+            1.0 / self.control_frequency_hands,
+            synchronise_speed=False,
         )
 
         # Configure right hand servo manager
@@ -82,7 +84,9 @@ class ServoManagerNode(Node):
             f"{config_folder_path}/servo_hand_right_params.json",
         ]
         self.driver_hand_right = ElrikDriverHandRight(
-            json_files_hand_right, self.control_frequency_hands, synchronise_speed=False
+            json_files_hand_right,
+            1.0 / self.control_frequency_hands,
+            synchronise_speed=False,
         )
 
         self.servo_commands_hands = (

--- a/pkgs_control/servo_control/servo_control/src/elrik_driver_arms.py
+++ b/pkgs_control/servo_control/servo_control/src/elrik_driver_arms.py
@@ -30,7 +30,6 @@ class ElrikDriverArms(ElrikDriverServos):
 
     def __del__(self):
         self.running = False
-        self.loop_thread.join()
         self.port_handler.closePort()
 
     def setup_driver(self):
@@ -97,7 +96,9 @@ class ElrikDriverArms(ElrikDriverServos):
             )
 
             if scs_addparam_result != True:
-                print(f"groupSyncWrite addparam failed, servo ID: {servo.servo_id}")
+                self.logger.warning(
+                    f"groupSyncWrite addparam failed, servo ID: {servo.servo_id}"
+                )
 
     def read_feedback(self, servo: ServoControl):
         try:

--- a/pkgs_control/servo_control/servo_control/src/elrik_driver_arms.py
+++ b/pkgs_control/servo_control/servo_control/src/elrik_driver_arms.py
@@ -10,7 +10,7 @@ from servo_control.src.elrik_driver_servos import ElrikDriverServos
 from servo_control.src.servo_control import ServoControl
 
 PORT = "/dev/ttyUSB0"
-BAUDRATE = 1000000
+BAUDRATE = 115200
 
 
 class ElrikDriverArms(ElrikDriverServos):

--- a/pkgs_control/servo_control/servo_control/src/elrik_driver_arms.py
+++ b/pkgs_control/servo_control/servo_control/src/elrik_driver_arms.py
@@ -9,7 +9,7 @@ from servo_control.src.elrik_driver_servos import ElrikDriverServos
 from servo_control.src.servo_control import ServoControl
 
 PORT = "/dev/ttyUSB0"
-BAUDRATE = 115200
+BAUDRATE = 1000000
 
 
 class ElrikDriverArms(ElrikDriverServos):

--- a/pkgs_control/servo_control/servo_control/src/elrik_driver_arms.py
+++ b/pkgs_control/servo_control/servo_control/src/elrik_driver_arms.py
@@ -2,7 +2,8 @@
 Servo driver/manager of Elrik arms, which are servos controlled by a Waveshare driver.
 """
 
-from threading import Lock
+import threading
+import time
 
 from .SCServo_Python.scservo_sdk import PortHandler, sms_sts, scservo_def
 from servo_control.src.elrik_driver_servos import ElrikDriverServos
@@ -18,21 +19,33 @@ class ElrikDriverArms(ElrikDriverServos):
             self, config_files, control_frequency, synchronise_speed=False
         )
 
-        self.lock = Lock()
+        self.port_handler = None
+        self.running = True
+        self.lock = threading.Lock()
+
+        self.loop_thread = threading.Thread(
+            target=self.loop_send_command, args=(control_frequency,), daemon=True
+        )
+        self.loop_thread.start()
+
+    def __del__(self):
+        self.running = False
+        self.loop_thread.join()
+        self.port_handler.closePort()
 
     def setup_driver(self):
 
         self.logger.info("Initializing serial communication with Waveshare...")
 
         try:
-            port_handler = PortHandler(PORT)
-            packet_handler = sms_sts(port_handler)
+            self.port_handler = PortHandler(PORT)
+            packet_handler = sms_sts(self.port_handler)
 
-            if not port_handler.openPort():
+            if not self.port_handler.openPort():
                 self.logger.error("Failed to open port")
                 return None
 
-            if not port_handler.setBaudRate(BAUDRATE):
+            if not self.port_handler.setBaudRate(BAUDRATE):
                 self.logger.error("Failed to set baud rate")
                 return None
 
@@ -43,19 +56,48 @@ class ElrikDriverArms(ElrikDriverServos):
             self.logger.error(f"Failed to open port: {e}")
             return None
 
-    def send_command(self, servo: ServoControl, pwm):
-        # self.logger.info(f"Servo: {servo.servo_id}. Stopping pwm of: {pwm}")
-        # return
+    def loop_send_command(self, frequency=50):
+        interval = 1.0 / frequency
+
+        while self.running:
+            start = time.time()
+            self.send_command_sync()
+            elapsed = time.time() - start
+            time.sleep(max(0, interval - elapsed))
+
+    def send_command_sync(self):
 
         with self.lock:
-            scs_comm_result, scs_error = self.driver_object.WritePosEx(
-                servo.servo_id, pwm, SCS_MOVING_SPEED := 2000, SCS_MOVING_ACC := 64
+            # self.logger.info(f"Sync send")
+            # return
+
+            # Syncwrite goal position
+            scs_comm_result = self.driver_object.groupSyncWrite.txPacket()
+
+            if scs_comm_result != scservo_def.COMM_SUCCESS:
+                self.logger.error(
+                    f"Communication error: {self.driver_object.getTxRxResult(scs_comm_result)}"
+                )
+
+            # Clear syncwrite parameter storage
+            self.driver_object.groupSyncWrite.clearParam()
+
+    def send_command(self, servo: ServoControl, pwm):
+
+        with self.lock:
+            # self.logger.info(f"Servo: {servo.servo_id}. Stopping pwm of: {pwm}")
+            # return
+
+            # Add SC position\moving speed\moving accc value to the Syncwrite parameter storage
+            scs_addparam_result = self.driver_object.SyncWritePosEx(
+                servo.servo_id,
+                pwm,
+                SCS_MOVING_SPEED := 2000,
+                SCS_MOVING_ACC := 64,
             )
 
-        # if scs_comm_result != scservo_def.COMM_SUCCESS:
-        #     self.logger.error(f"Communication error: {scs_comm_result}")
-        # elif scs_error != 0:
-        #     self.logger.error(f"Servo error: {scs_error}")
+            if scs_addparam_result != True:
+                print(f"groupSyncWrite addparam failed, servo ID: {servo.servo_id}")
 
     def read_feedback(self, servo: ServoControl):
         try:

--- a/pkgs_control/servo_control/servo_control/src/elrik_driver_servos.py
+++ b/pkgs_control/servo_control/servo_control/src/elrik_driver_servos.py
@@ -26,7 +26,6 @@ class ElrikDriverServos(ABC):
         self.control_frequency = control_frequency
         self.synchronise_speed = synchronise_speed
         self.servos = {}
-        self.coms_active = False
 
         # Load and process JSON files
         for json_file in config_files:


### PR DESCRIPTION
# WHY

Each write call to a Waveshare servo takes ~0.05s, which tanks the finger servos update rate.
A way to decrease the write speed, or multiprocessing, is needed.

# WHAT

Implemented sync-write.

# HOW

Mulitprocessing is a complicated solution as there can only be one driver object, which cannot be shared between processes. 
The control and conversion code could be run in different processes and passed to the driver through a queue, but as it is the write speed that is the limiting factor, this does not address the problem.

The SCSservo_Python library implements a group sync write function, so we can compute the PWM command for each servo and collect them in a container, that can then be bulk sent all at once. This drastically increased performance. 



